### PR TITLE
Updated UI section sidebar navigation to include sections

### DIFF
--- a/client/components/ui-design-system/base-styles/colors/index.jsx
+++ b/client/components/ui-design-system/base-styles/colors/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UIColors = () => (
   <div className="wrap">
@@ -39,7 +39,7 @@ const UIColors = () => (
         </span>
       </div>
     </div>
-    <div className="row u-mb-5">    
+    <div className="row u-mb-5">
       <div className="columns small-3">
         <span className="color-block dark-blue">
           <span className="code">@navyBlue</span>
@@ -89,7 +89,7 @@ const UIColors = () => (
         </span>
       </div>
     </div>
-    <div className="row u-mb-5">    
+    <div className="row u-mb-5">
       <div className="columns small-3">
         <span className="color-block gray4">
           <span className="code">@gray4</span>

--- a/client/components/ui-design-system/base-styles/icons/index.jsx
+++ b/client/components/ui-design-system/base-styles/icons/index.jsx
@@ -1,0 +1,15 @@
+// ==================================================
+// DesignSystem - DSIcons
+// ==================================================
+
+import React from 'react';
+import '../../../../styling/root.less';
+
+const UIIcons = () => (
+  <div className="wrap">
+    <h1 className="heading">Icons</h1>
+    <p>Let's get some icons in here.</p>
+  </div>
+);
+
+export default UIIcons;

--- a/client/components/ui-design-system/base-styles/typography/index.jsx
+++ b/client/components/ui-design-system/base-styles/typography/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UITypography = () => (
   <div className="wrap">

--- a/client/components/ui-design-system/components/banners/index.jsx
+++ b/client/components/ui-design-system/components/banners/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UIBanners = () => (
   <div className="wrap button-ui">

--- a/client/components/ui-design-system/components/bubbles/index.jsx
+++ b/client/components/ui-design-system/components/bubbles/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UIBubbles = () => (
   <div className="wrap button-ui">

--- a/client/components/ui-design-system/components/buttons/index.jsx
+++ b/client/components/ui-design-system/components/buttons/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UIButtons = () => (
   <div className="wrap button-ui">
@@ -38,7 +38,7 @@ const UIButtons = () => (
         </pre>
       </div>
     </div>
-    
+
     <div className="row u-mb-2">
       <div className="columns small-12">
         <h3>Dark Background</h3>

--- a/client/components/ui-design-system/components/code/index.jsx
+++ b/client/components/ui-design-system/components/code/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UICode = () => (
   <div className="wrap">
@@ -196,7 +196,7 @@ const UICode = () => (
                     <span>"95"</span>
                   </div>
                 </div>
-              </div> 
+              </div>
             </div>
           </div>
           <div>

--- a/client/components/ui-design-system/components/forms/index.jsx
+++ b/client/components/ui-design-system/components/forms/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UIForms = () => (
   <div className="wrap">

--- a/client/components/ui-design-system/components/tables/index.jsx
+++ b/client/components/ui-design-system/components/tables/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UITables = () => (
   <div className="wrap">

--- a/client/components/ui-design-system/components/tabs/index.jsx
+++ b/client/components/ui-design-system/components/tabs/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UITabs = () => (
   <div className="wrap button-ui">

--- a/client/components/ui-design-system/components/utilities/index.jsx
+++ b/client/components/ui-design-system/components/utilities/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UIUtilities = () => (
   <div className="wrap button-ui">

--- a/client/components/ui-design-system/components/view-modal/index.jsx
+++ b/client/components/ui-design-system/components/view-modal/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UIViewModal = () => (
   <div className="wrap">

--- a/client/components/ui-design-system/index.jsx
+++ b/client/components/ui-design-system/index.jsx
@@ -9,20 +9,38 @@ import '../../styling/root.less';
 const UIDesignSystem = ({ children }) => (
   <div className="wrap">
     <nav className="sidebar">
-    	<ul>
-            <li><Link to='/ui-design-system/' className="link">Welcome</Link></li>
-            <li><Link to='/ui-design-system/banners' className="link">Banners</Link></li>
-            <li><Link to='/ui-design-system/bubbles' className="link">Bubbles</Link></li>
-            <li><Link to='/ui-design-system/buttons' className="link">Buttons</Link></li>
-            <li><Link to='/ui-design-system/code' className="link">Code</Link></li>
-            <li><Link to='/ui-design-system/colors' className="link">Colors</Link></li>
-            <li><Link to='/ui-design-system/forms' className="link">Forms</Link></li>
-            <li><Link to='/ui-design-system/grid' className="link">Grid</Link></li>
-            <li><Link to='/ui-design-system/view-modal' className="link">Modals</Link></li>
-            <li><Link to='/ui-design-system/tabs' className="link">Tabs</Link></li>
-            <li><Link to='/ui-design-system/tables' className="link">Tables</Link></li>
-            <li><Link to='/ui-design-system/typography' className="link">Typography</Link></li>
-            <li><Link to='/ui-design-system/utilities' className="link">Utilities</Link></li>
+      <ul>
+            <li><h4>Base Styles</h4>
+              <ul>
+                  <li><Link to='/ui-design-system/base-styles/colors' className="link">Colors</Link></li>
+                  <li><Link to='/ui-design-system/base-styles/icons' className="link">Icons</Link></li>
+                  <li><Link to='/ui-design-system/base-styles/typography' className="link">Typography</Link></li>
+              </ul>
+            </li>
+            <li><h4>Components</h4>
+              <ul>
+                <li><Link to='/ui-design-system/components/banners' className="link">Banners</Link></li>
+                <li><Link to='/ui-design-system/components/bubbles' className="link">Bubbles</Link></li>
+                <li><Link to='/ui-design-system/components/buttons' className="link">Buttons</Link></li>
+                <li><Link to='/ui-design-system/components/code' className="link">Code</Link></li>
+                <li><Link to='/ui-design-system/components/forms' className="link">Forms</Link></li>
+                <li><Link to='/ui-design-system/components/view-modal' className="link">Modals</Link></li>
+                <li><Link to='/ui-design-system/components/tabs' className="link">Tabs</Link></li>
+                <li><Link to='/ui-design-system/components/tables' className="link">Tables</Link></li>
+                <li><Link to='/ui-design-system/components/utilities' className="link">Utilities</Link></li>
+              </ul>
+            </li>
+            <li><h4>Patterns</h4>
+                <ul>
+                  <li><Link to='/ui-design-system/patterns/modify' className="link">Modify</Link></li>
+                </ul>
+            </li>
+            <li><h4>Layouts</h4>
+                <ul>
+                  <li><Link to='/ui-design-system/layouts/grid' className="link">Grid</Link></li>
+                </ul>
+            </li>
+
     	</ul>
     </nav>
     <div className="content">{children}</div>

--- a/client/components/ui-design-system/layouts/grid/index.jsx
+++ b/client/components/ui-design-system/layouts/grid/index.jsx
@@ -3,7 +3,7 @@
 // ==================================================
 
 import React from 'react';
-import '../../../styling/root.less';
+import '../../../../styling/root.less';
 
 const UIGrid = () => (
   <div className="wrap">

--- a/client/components/ui-design-system/patterns/modify/index.jsx
+++ b/client/components/ui-design-system/patterns/modify/index.jsx
@@ -1,0 +1,15 @@
+// ==================================================
+// DesignSystem - UIModify
+// ==================================================
+
+import React from 'react';
+import '../../../../styling/root.less';
+
+const UIModify = () => (
+  <div className="wrap">
+    <h1 className="heading">Modifying Elements</h1>
+    <p>Let's start with an example from Compass CRUD.</p>
+  </div>
+);
+
+export default UIModify;

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -13,18 +13,24 @@ import BrandLogo from './components/brand-design-system/logo/index.jsx';
 
 import UIDesignSystem from './components/ui-design-system/index.jsx';
 import UIWelcome from './components/ui-design-system/welcome/index.jsx';
-import UITypography from './components/ui-design-system/typography/index.jsx';
-import UICode from './components/ui-design-system/code/index.jsx';
-import UIColors from './components/ui-design-system/colors/index.jsx';
-import UIBanners from './components/ui-design-system/banners/index.jsx';
-import UIButtons from './components/ui-design-system/buttons/index.jsx';
-import UIBubbles from './components/ui-design-system/bubbles/index.jsx';
-import UIGrid from './components/ui-design-system/grid/index.jsx';
-import UIForms from './components/ui-design-system/forms/index.jsx';
-import UITabs from './components/ui-design-system/tabs/index.jsx';
-import UITables from './components/ui-design-system/tables/index.jsx';
-import UIUtilities from './components/ui-design-system/utilities/index.jsx';
-import UIViewModal from './components/ui-design-system/view-modal/index.jsx';
+//Base Styles
+import UIColors from './components/ui-design-system/base-styles/colors/index.jsx';
+import UIIcons from './components/ui-design-system/base-styles/icons/index.jsx';
+import UITypography from './components/ui-design-system/base-styles/typography/index.jsx';
+//Components
+import UICode from './components/ui-design-system/components/code/index.jsx';
+import UIBanners from './components/ui-design-system/components/banners/index.jsx';
+import UIButtons from './components/ui-design-system/components/buttons/index.jsx';
+import UIBubbles from './components/ui-design-system/components/bubbles/index.jsx';
+import UIForms from './components/ui-design-system/components/forms/index.jsx';
+import UITabs from './components/ui-design-system/components/tabs/index.jsx';
+import UITables from './components/ui-design-system/components/tables/index.jsx';
+import UIUtilities from './components/ui-design-system/components/utilities/index.jsx';
+import UIViewModal from './components/ui-design-system/components/view-modal/index.jsx';
+//Patterns
+import UIModify from './components/ui-design-system/patterns/modify/index.jsx';
+//Layouts
+import UIGrid from './components/ui-design-system/layouts/grid/index.jsx';
 
 const routes = (
   <Route path="/" component={Layout}>
@@ -37,18 +43,24 @@ const routes = (
     </Route>
     <Route path="/ui-design-system" component={UIDesignSystem}>
         <IndexRoute component={UIWelcome} />
-        <Route path="/ui-design-system/typography" component={UITypography} />
-        <Route path="/ui-design-system/code" component={UICode} />
-        <Route path="/ui-design-system/colors" component={UIColors} />
-        <Route path="/ui-design-system/banners" component={UIBanners} />
-        <Route path="/ui-design-system/bubbles" component={UIBubbles} />
-        <Route path="/ui-design-system/buttons" component={UIButtons} />
-        <Route path="/ui-design-system/grid" component={UIGrid} />
-        <Route path="/ui-design-system/forms" component={UIForms} />
-        <Route path="/ui-design-system/tabs" component={UITabs} />
-        <Route path="/ui-design-system/tables" component={UITables} />
-        <Route path="/ui-design-system/utilities" component={UIUtilities} />
-        <Route path="/ui-design-system/view-modal" component={UIViewModal} />
+        //Base Styles
+        <Route path="/ui-design-system/base-styles/colors" component={UIColors} />
+        <Route path="/ui-design-system/base-styles/icons" component={UIIcons} />
+        <Route path="/ui-design-system/base-styles/typography" component={UITypography} />
+        //Components
+        <Route path="/ui-design-system/components/code" component={UICode} />
+        <Route path="/ui-design-system/components/banners" component={UIBanners} />
+        <Route path="/ui-design-system/components/bubbles" component={UIBubbles} />
+        <Route path="/ui-design-system/components/buttons" component={UIButtons} />
+        <Route path="/ui-design-system/components/forms" component={UIForms} />
+        <Route path="/ui-design-system/components/tabs" component={UITabs} />
+        <Route path="/ui-design-system/components/tables" component={UITables} />
+        <Route path="/ui-design-system/components/utilities" component={UIUtilities} />
+        <Route path="/ui-design-system/components/view-modal" component={UIViewModal} />
+        //Patterns
+        <Route path="/ui-design-system/patterns/modify" component={UIModify} />
+        //Layouts
+        <Route path="/ui-design-system/layouts/grid" component={UIGrid} />
     </Route>
     <Route path="*" component={NotFound} />
   </Route>

--- a/client/styling/root.less
+++ b/client/styling/root.less
@@ -125,6 +125,7 @@ nav.sidebar {
 
 nav.sidebar ul {
   list-style: none;
+  padding-bottom: 24px;
 }
 
 nav.sidebar ul li {


### PR DESCRIPTION
![screenshot 2017-07-26 11 57 12](https://user-images.githubusercontent.com/489217/28630927-a18ffd86-71f9-11e7-9ce9-b9bbce9430a1.png)

@sampoonachot @marcgurney 
Added some sections to the sidebar navigation.

There is a "patterns" section now, where we can add patterns of component use. One that I want to start with is editing an element in Compass. It's a repeatable pattern, but is most established in the Compass CRUD feature. I think I'll spend some time with Matt next week adding the core components (somewhere) and then adding language into the patterns section to illustrate how the component is used.

I also added the "layouts" section where I think we can start hinting at the product-specific app layouts when it makes sense. In our doc, we started thinking about how to break components down by product, but thinking about it some more it probably is a good idea to continue pushing product-agnostic components first and foremost, and then just think about how they might be laid out differently across our products.

Thoughts?