### PR TITLE
Fix Padding and Margin bug in Compass Query History Cards

### DIFF
--- a/client/styling/query-history.less
+++ b/client/styling/query-history.less
@@ -116,6 +116,11 @@
   &-card {
     color: #494747;
 
+    ul {
+      margin: 0;
+      padding: 0;
+    }
+
     // Code Snippet
     pre {
       padding: 0;


### PR DESCRIPTION
Bug introduced from [PD-10 PR](https://github.com/leafygreen/design/pull/29). Fixed by adding specific margin / padding values in `query-history.less` to override new defaults. 