### PR TITLE
Update package.json to include prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-router": "^2.6.1",
     "react-router-scroll": "^0.3.1",
     "style-loader": "^0.13.1",
-    "prop-types": "15.5.10",
+    "prop-types": "15.5.10"
   },
   "devDependencies": {
     "nwb": "0.18.x",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-helmet": "^3.1.0",
     "react-router": "^2.6.1",
     "react-router-scroll": "^0.3.1",
-    "style-loader": "^0.13.1"
+    "style-loader": "^0.13.1",
+    "prop-types": "15.5.10",
   },
   "devDependencies": {
     "nwb": "0.18.x",


### PR DESCRIPTION
Adding missing `prop-types` required in the recent react components migrated from Cloud.