### PR TITLE
Github API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 nginx.conf
 npm-debug.log
 webpack-assets.json
+config.js

--- a/client/components/ui-design-system/resources/index.jsx
+++ b/client/components/ui-design-system/resources/index.jsx
@@ -4,25 +4,54 @@
 
 import React from 'react';
 import '../../../styling/root.less';
+import config from '../../../../config.js'
+
+var token = config.gitkey;
 
 class Resources extends React.Component {
-  componentDidMount() {
-    return fetch("https://api.github.com/graphql", {
-  body: "{\"query\": \"query FindLatestCommit { repository(owner: \"leafygreen\", name: \"sketchUIlibrary\") { ref(qualifiedName: \"master\") { target { ... on Commit { history(first:1, path: \"_mongodb-core.sketch\") { edges { node { messageHeadline committedDate } } } } } } } }\"}",
-  headers: {
-    Authorization: "bearer f2af351e7137826fae5580c827d175816ad7349e",
-    "Content-Type": "application/x-www-form-urlencoded"
-  },
-  method: "POST"
-})
-      .then((response) => response.json())
-      .then((responseJson) => {
-        console.log(responseJson);
+  state = {
+    coreLastUpdated: '',
+    compassLastUpdated: '',
+    cloudLastUpdated: '',
+    stitchLastUpdated: '',
+    universityLastUpdated: ''
+  }
+
+  // Fetch last commit dates for each sketch file
+  componentWillMount() {
+    var files = [ "_mongodb-core.sketch", "_compass-template-1.7.sketch", "_cloud-template.sketch", "_stitch-template.sketch", "_university-template-1.2.sketch" ];
+    var statePairing = [
+      ["_mongodb-core.sketch", "coreLastUpdated"],
+      ["_compass-template-1.7.sketch", "compassLastUpdated"],
+      ["_cloud-template.sketch", "cloudLastUpdated"],
+      ["_stitch-template.sketch", "stitchLastUpdated"],
+      ["_university-template-1.2.sketch", "universityLastUpdated"],
+    ];
+    var stateMap = new Map(statePairing);
+
+    var queryTemplate = `query FindLatestCommit($file: String) { repository(owner: \"leafygreen\", name: \"sketchUIlibrary\") { ref(qualifiedName: \"master\") { target { ... on Commit { history(first:1, path: $file) { edges { node { messageHeadline committedDate } } } } } } } }`
+    files.map(files => { 
+      fetch("https://api.github.com/graphql", {
+        body: JSON.stringify({
+          query: queryTemplate,
+          variables: { file: files },
+        }),
+        headers: {
+          Authorization: `bearer ${token}`,
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        method: "POST"
       })
-      .catch((error) => {
-        console.error(error);
-      }
-    );
+        .then((response) => response.json())
+        .then((responseJson) => {
+          var updatedDate = responseJson.data.repository.ref.target.history.edges[0].node.committedDate.split('T')[0];
+          var fileState = stateMap.get(files);
+          this.setState( {
+            [fileState]: updatedDate
+          });
+        }
+      );
+    })
   }
 
   render() {
@@ -41,6 +70,7 @@ class Resources extends React.Component {
                 <tr className="table-row">
                   <th className="table-header">Filename</th>
                   <th className="table-header">Description</th>
+                  <th className="table-header">Last Updated</th>
                 </tr>
               </thead>
               <tbody>
@@ -49,30 +79,36 @@ class Resources extends React.Component {
                     <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_mongodb-core.sketch?raw=true"><strong>_mongodb-core.sketch</strong></a>
                   </td>
                   <td className="table-column table-cell">Core components common to all MongoDB products</td>
+                  <td className="table-column table-cell">{this.state.coreLastUpdated}</td>
                 </tr>
                 <tr className="table-row">
                   <td className="table-column table-cell">
                     <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_compass-template-1.7.sketch?raw=true"><strong>_compass-template-1.7.sketch</strong></a>
                   </td>
                   <td className="table-column table-cell">Components and layouts for MongoDB Compass</td>
+                  <td className="table-column table-cell">{this.state.compassLastUpdated}</td>
                 </tr>
                 <tr className="table-row">
                   <td className="table-column table-cell">
                     <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_cloud-template.sketch?raw=true"><strong>_cloud-template.sketch</strong></a>
                   </td>
                   <td className="table-column table-cell">Components and layouts for MongoDB Cloud Manager, Ops Manager, and Atlas</td>
+                  <td className="table-column table-cell">{this.state.cloudLastUpdated}</td>
+
                 </tr>
                 <tr className="table-row">
                   <td className="table-column table-cell">
                     <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_stitch-template.sketch?raw=true"><strong>_stitch-template.sketch</strong></a>
                   </td>
                   <td className="table-column table-cell">Components and layouts for MongoDB Stitch</td>
+                  <td className="table-column table-cell">{this.state.stitchLastUpdated}</td>
                 </tr>
                 <tr className="table-row">
                   <td className="table-column table-cell">
                     <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_university-template-1.2.sketch?raw=true"><strong>_university-template-1.2.sketch</strong></a>
                   </td>
                   <td className="table-column table-cell">Components and layouts for MongoDB University</td>
+                  <td className="table-column table-cell">{this.state.universityLastUpdated}</td>
                 </tr>
               </tbody>
             </table>

--- a/client/components/ui-design-system/resources/index.jsx
+++ b/client/components/ui-design-system/resources/index.jsx
@@ -5,65 +5,88 @@
 import React from 'react';
 import '../../../styling/root.less';
 
-const Resources = () => (
-  <div className="wrap">
-    <div className="row u-mb-3">
-      <div className="columns small-12">
-        <h1 className="heading">Resources</h1>
+class Resources extends React.Component {
+  componentDidMount() {
+    return fetch("https://api.github.com/graphql", {
+  body: "{\"query\": \"query FindLatestCommit { repository(owner: \"leafygreen\", name: \"sketchUIlibrary\") { ref(qualifiedName: \"master\") { target { ... on Commit { history(first:1, path: \"_mongodb-core.sketch\") { edges { node { messageHeadline committedDate } } } } } } } }\"}",
+  headers: {
+    Authorization: "bearer f2af351e7137826fae5580c827d175816ad7349e",
+    "Content-Type": "application/x-www-form-urlencoded"
+  },
+  method: "POST"
+})
+      .then((response) => response.json())
+      .then((responseJson) => {
+        console.log(responseJson);
+      })
+      .catch((error) => {
+        console.error(error);
+      }
+    );
+  }
+
+  render() {
+    return (
+      <div className="wrap">
+        <div className="row u-mb-3">
+          <div className="columns small-12">
+            <h1 className="heading">Resources</h1>
+          </div>
+        </div>
+        <div className="row u-mb-3">
+          <div className="columns small-12">
+            <h2 className="heading">Sketch Templates</h2>
+            <table className="table">
+              <thead>
+                <tr className="table-row">
+                  <th className="table-header">Filename</th>
+                  <th className="table-header">Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_mongodb-core.sketch?raw=true"><strong>_mongodb-core.sketch</strong></a>
+                  </td>
+                  <td className="table-column table-cell">Core components common to all MongoDB products</td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_compass-template-1.7.sketch?raw=true"><strong>_compass-template-1.7.sketch</strong></a>
+                  </td>
+                  <td className="table-column table-cell">Components and layouts for MongoDB Compass</td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_cloud-template.sketch?raw=true"><strong>_cloud-template.sketch</strong></a>
+                  </td>
+                  <td className="table-column table-cell">Components and layouts for MongoDB Cloud Manager, Ops Manager, and Atlas</td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_stitch-template.sketch?raw=true"><strong>_stitch-template.sketch</strong></a>
+                  </td>
+                  <td className="table-column table-cell">Components and layouts for MongoDB Stitch</td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_university-template-1.2.sketch?raw=true"><strong>_university-template-1.2.sketch</strong></a>
+                  </td>
+                  <td className="table-column table-cell">Components and layouts for MongoDB University</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div className="row u-mb-3">
+          <div className="columns small-12">
+            <h2 className="heading">Brand Guide</h2>
+            <p>Looking for the brand guide? Visit the <a href="https://mongodb.frontify.com" target="_blank">MongoDB Brand Portal</a> for logos, icons, color palettes, illustration guidelines, and more.</p>
+          </div>
+        </div>
       </div>
-    </div>
-    <div className="row u-mb-3">
-      <div className="columns small-12">
-        <h2 className="heading">Sketch Templates</h2>
-        <table className="table">
-          <thead>
-            <tr className="table-row">
-              <th className="table-header">Filename</th>
-              <th className="table-header">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="table-row">
-              <td className="table-column table-cell">
-                <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_mongodb-core.sketch?raw=true"><strong>_mongodb-core.sketch</strong></a>
-              </td>
-              <td className="table-column table-cell">Core components common to all MongoDB products</td>
-            </tr>
-            <tr className="table-row">
-              <td className="table-column table-cell">
-                <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_compass-template-1.7.sketch?raw=true"><strong>_compass-template-1.7.sketch</strong></a>
-              </td>
-              <td className="table-column table-cell">Components and layouts for MongoDB Compass</td>
-            </tr>
-            <tr className="table-row">
-              <td className="table-column table-cell">
-                <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_cloud-template.sketch?raw=true"><strong>_cloud-template.sketch</strong></a>
-              </td>
-              <td className="table-column table-cell">Components and layouts for MongoDB Cloud Manager, Ops Manager, and Atlas</td>
-            </tr>
-            <tr className="table-row">
-              <td className="table-column table-cell">
-                <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_stitch-template.sketch?raw=true"><strong>_stitch-template.sketch</strong></a>
-              </td>
-              <td className="table-column table-cell">Components and layouts for MongoDB Stitch</td>
-            </tr>
-            <tr className="table-row">
-              <td className="table-column table-cell">
-                <a href="https://github.com/leafygreen/sketchUILibrary/blob/master/_university-template-1.2.sketch?raw=true"><strong>_university-template-1.2.sketch</strong></a>
-              </td>
-              <td className="table-column table-cell">Components and layouts for MongoDB University</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div className="row u-mb-3">
-      <div className="columns small-12">
-        <h2 className="heading">Brand Guide</h2>
-        <p>Looking for the brand guide? Visit the <a href="https://mongodb.frontify.com" target="_blank">MongoDB Brand Portal</a> for logos, icons, color palettes, illustration guidelines, and more.</p>
-      </div>
-    </div>
-  </div>
-);
+    );
+  }
+}
 
 export default Resources;


### PR DESCRIPTION
## Overview
This PR modifies the sketch files table on the resources page to include a third column: last updated. I'm fetching this data via Github's graphql API and appending the date string to different states that are displayed for each file.

We can definitely optimize this query process in the future (in more ways than one), but I think it's safe to merge for now. 

## Important!
For security purposes, you will need to create a `config.js` file to the root directory of your design system. In this file, you can add the following code:
```
var config = {
  gitkey : 'YOUR PERSONAL ACCESS TOKEN HERE'
}

export default config;
```
You can generate a personal access token here following these [instructions](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/). As far as I'm aware, you only need the following scopes enabled:
- [ ] repo:status
- [ ] repo_deployment
- [ ] public_repo
- [ ] read:repo_hook

You will only need to do this once - your config.js file will be ignored by any git updates. 