### PR TITLE
Adding Prop Sections for React Components

### DIFF
--- a/client/components/ui-design-system/components/banners/react-banners.jsx
+++ b/client/components/ui-design-system/components/banners/react-banners.jsx
@@ -45,7 +45,6 @@ class UIBannersReact extends React.Component {
           <h1>Banners</h1>
         </div>
       </div>
-
       <div className="row u-mb-2">
         <div className="columns small-12">
           <ul className="tabs">
@@ -58,14 +57,12 @@ class UIBannersReact extends React.Component {
           </ul>
         </div>
       </div>
-
       <div className="row u-mb-3">
         <div className="columns small-12">
           <h2>Alerts</h2>
           <p>Alerts are available in four levels – success, warning, danger, and info.</p>
         </div>
       </div>
-
       <div className="row u-mb-3">
         <div className="columns small-12">
           <Alert 
@@ -75,10 +72,12 @@ class UIBannersReact extends React.Component {
           />
         </div>
       </div>
-
       <div className="row u-mb-2">
+        <div className="columns small-12">
+          <h3>Options</h3>
+        </div>
         <div className="columns small-6">
-          <h4>Type</h4>
+          <p><b>Type</b></p>
           <RadioGroup
             name="alert-state"
             selectedValue={this.state.controlLevel}
@@ -101,9 +100,8 @@ class UIBannersReact extends React.Component {
             </label>
           </RadioGroup>
         </div>
-
         <div className="columns small-6">
-          <h4>State</h4>
+          <p><b>Type</b></p>
           <Checkbox 
               label="Dismissible"
               checked={this.state.controlDismissible}
@@ -111,13 +109,75 @@ class UIBannersReact extends React.Component {
           />
         </div>
       </div>
-
       <div className="row u-mb-3">
         <div className="columns small-12">
           <Code
             language='language-jsx'
             text={this.codeSnippetHandler()}>
           </Code>
+        </div>
+      </div>
+      <div className="row u-mb-3">
+        <div className="columns small-12">
+          <h3>Available Props</h3>
+          <table className="table">
+            <thead>
+              <tr className="table-row">
+                <th className="table-header">Prop Name</th>
+                <th className="table-header">Type</th>
+                <th className="table-header">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="table-row">
+                <td className="table-column table-cell">
+                  <p className="code">level</p>
+                </td>
+                <td className="table-column table-cell">
+                  <p><b>String, Required</b></p>
+                </td>
+                <td className="table-column table-cell">
+                  <p>Default = <b>info</b></p>
+                  <p>Defines the color state of the banner</p>
+                  <p><b>Must be one of the following:</b> success, warning, danger, info</p>
+                </td>
+              </tr>
+              <tr className="table-row">
+                <td className="table-column table-cell">
+                  <p className="code">dismissible</p>
+                </td>
+                <td className="table-column table-cell">
+                  <p><b>boolean</b></p>
+                </td>
+                <td className="table-column table-cell">
+                  <p>Default = <b>false</b></p>
+                  <p>Defines whether the user can close the banner</p>
+                </td>
+              </tr>
+              <tr className="table-row">
+                <td className="table-column table-cell">
+                  <p className="code">onDismiss</p>
+                </td>
+                <td className="table-column table-cell">
+                  <p><b>Function</b></p>
+                </td> 
+                <td className="table-column table-cell">
+                  <p>Click event handler for the × close button</p>
+                </td>
+              </tr>
+              <tr className="table-row">
+                <td className="table-column table-cell">
+                  <p className="code">children</p>
+                </td>
+                <td className="table-column table-cell">
+                  <p><b>Node</b></p>
+                </td>
+                <td className="table-column table-cell">
+                  <p>A collection of child elements of the banner</p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
   </div>

--- a/client/components/ui-design-system/components/buttons/react-buttons.jsx
+++ b/client/components/ui-design-system/components/buttons/react-buttons.jsx
@@ -78,7 +78,7 @@ class UIButtonsReact extends React.Component {
         </div>
         <div className="row u-mb-2">
           <div className="columns small-6">
-            <h4>Type</h4>
+            <p><b>Type</b></p>
             <RadioGroup
               name="button-state"
               selectedValue={this.state.controlTypeClassName}
@@ -105,7 +105,7 @@ class UIButtonsReact extends React.Component {
             </RadioGroup>
           </div>
           <div className="columns small-6">
-            <h4>State</h4>
+            <p><b>State</b></p>
             <Checkbox 
                 label="Disabled"
                 checked={this.state.controlDisabled}

--- a/client/components/ui-design-system/components/buttons/react-buttons.jsx
+++ b/client/components/ui-design-system/components/buttons/react-buttons.jsx
@@ -71,12 +71,10 @@ class UIButtonsReact extends React.Component {
             />
           </div>
         </div>
-        <div className="row">
+        <div className="row u-mb-2">
           <div className="columns small-12">
             <h3>Options</h3>
           </div>
-        </div>
-        <div className="row u-mb-2">
           <div className="columns small-6">
             <p><b>Type</b></p>
             <RadioGroup
@@ -105,7 +103,7 @@ class UIButtonsReact extends React.Component {
             </RadioGroup>
           </div>
           <div className="columns small-6">
-            <p><b>State</b></p>
+            <p><b>state</b></p>
             <Checkbox 
                 label="Disabled"
                 checked={this.state.controlDisabled}

--- a/client/components/ui-design-system/components/buttons/react-buttons.jsx
+++ b/client/components/ui-design-system/components/buttons/react-buttons.jsx
@@ -121,6 +121,100 @@ class UIButtonsReact extends React.Component {
             </Code>
           </div>
         </div>
+        <div className="row u-mb-3">
+          <div className="columns small-12">
+            <h3>Available Props</h3>
+            <table className="table">
+              <thead>
+                <tr className="table-row">
+                  <th className="table-header">Prop Name</th>
+                  <th className="table-header">Type</th>
+                  <th className="table-header">Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">onClick</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Function, Required</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Click event handler</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">className</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>String</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>CSS class(es) passed to the button</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">name</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>String</b></p>
+                  </td> 
+                  <td className="table-column table-cell">
+                    <p>Defines the name reference of the button</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">label</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Node</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Text rendered in the body of the button</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">children</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Node</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>A collection of child elements of the button. Can be used in place of the label prop</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">value</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>String</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Defines the default value of the button</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">disabled</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Boolean</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Default = <b>false</b></p>
+                    <p>Defines the disabled state of the button</p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
     );
   }

--- a/client/components/ui-design-system/components/code/react-copyablecommand.jsx
+++ b/client/components/ui-design-system/components/code/react-copyablecommand.jsx
@@ -51,14 +51,12 @@ class UICopyableCommandReact extends React.Component {
             </CopyableCommand>
           </div>
         </div>
-        <div className="row">
+        <div className="row u-mb-2">
           <div className="columns small-12">
             <h3>Options</h3>
           </div>
-        </div>
-        <div className="row u-mb-2">
           <div className="columns small-6">
-            <h4>State</h4>
+            <p><b>State</b></p>
             <Checkbox 
                 label="Full Width"
                 checked={this.state.fullWidth}
@@ -74,6 +72,67 @@ class UICopyableCommandReact extends React.Component {
   copyableText='This is a command that you can copy. It will not break onto the next line since the overflow will keep scrolling horizontally.'>${isFullWidth}
 </CopyableCommand>`}> 
             </Code>
+          </div>
+        </div>
+        <div className="row u-mb-3">
+          <div className="columns small-12">
+            <h3>Available Props</h3>
+            <table className="table">
+              <thead>
+                <tr className="table-row">
+                  <th className="table-header">Prop Name</th>
+                  <th className="table-header">Type</th>
+                  <th className="table-header">Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">copyableText</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>String, Required</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Text rendered as the code snippet</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">otherClasses</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>String</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Additional CSS class(es) passed to the parent wrapper</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">children</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Node</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>A collection of child elements of the code snippet</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">fullWidth</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Boolean</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Default = <b>false</b></p>
+                    <p>Defines whether the code snippet expands to take the full width of its parent container</p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>

--- a/client/components/ui-design-system/components/view-modal/react-view-modal.jsx
+++ b/client/components/ui-design-system/components/view-modal/react-view-modal.jsx
@@ -47,10 +47,42 @@ class UIViewModalReact extends React.Component {
             <h2>View Modal</h2>
             <p>The View Modal is a React component that can be configured to one of five preset sizes.</p>
           </div>
+
+        </div>
+        <div className="row u-mb-2">
+          <div className="columns small-12">
+          <Button
+            label={this.state.isOpen ? "Close Modal" : "Open Modal"}
+            onClick={() => this.toggleModal(this.state.isOpen)}
+          />
+          </div>
+          <Modal 
+            open={this.state.isOpen}
+            title="Your Title Here"
+            size={this.state.size}
+            onClose={() => this.toggleModal(this.state.isOpen)}
+            >
+            <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</p>
+            <Modal.ModalFooter>
+              <Button
+                label="Cancel"
+                className="u-mr-2"
+                onClick={() => this.toggleModal(this.state.isOpen)}
+              />
+              <Button
+                label="Confirm"
+                className="button-is-primary"
+                onClick={() => this.toggleModal(this.state.isOpen)}
+              />
+            </Modal.ModalFooter>
+          </Modal>
         </div>
         <div className="row u-mb-3">
+          <div className="columns small-12">
+            <h3>Options</h3>
+          </div>
           <div className="columns small-6">
-            <h4>Size</h4>
+            <p><b>Size</b></p>
             <RadioGroup
               name="button-state"
               selectedValue={this.state.size}
@@ -75,34 +107,6 @@ class UIViewModalReact extends React.Component {
         </div>
         <div className="row u-mb-3">
           <div className="columns small-12">
-            <Button
-              label={this.state.isOpen ? "Close Modal" : "Open Modal"}
-              onClick={() => this.toggleModal(this.state.isOpen)}
-            />
-            <Modal 
-              open={this.state.isOpen}
-              title="Your Title Here"
-              size={this.state.size}
-              onClose={() => this.toggleModal(this.state.isOpen)}
-              >
-              <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</p>
-              <Modal.ModalFooter>
-                <Button
-                  label="Cancel"
-                  className="u-mr-2"
-                  onClick={() => this.toggleModal(this.state.isOpen)}
-                />
-                <Button
-                  label="Confirm"
-                  className="button-is-primary"
-                  onClick={() => this.toggleModal(this.state.isOpen)}
-                />
-              </Modal.ModalFooter>
-            </Modal>
-          </div>
-        </div>
-        <div className="row u-mb-3">
-          <div className="columns small-12">
             <Code 
             language='language-jsx'
             text={`<Modal 
@@ -122,6 +126,102 @@ class UIViewModalReact extends React.Component {
   </Modal.ModalFooter>
 </Modal>`}> 
             </Code>
+          </div>
+        </div>
+        <div className="row u-mb-3">
+          <div className="columns small-12">
+            <h3>Available Props</h3>
+            <table className="table">
+              <thead>
+                <tr className="table-row">
+                  <th className="table-header">Prop Name</th>
+                  <th className="table-header">Type</th>
+                  <th className="table-header">Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">open</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Boolean</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Default = <b>true</b></p>
+                    <p>Defines the open state of the modal</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">title</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>String</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>The header text of the modal</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">children</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Node</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>A collection of child elements of the modal body.</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">size</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>String</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Defines the size of the modal</p>
+                    <p><b>Must be one of the following:</b> xs, small, medium, large, xlarge</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">hideClose</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Boolean</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Default = <b>false</b></p>
+                    <p>Defines the visibility of the × close button</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">onClose</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Function</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Click event handler for the × close button</p>
+                  </td>
+                </tr>
+                <tr className="table-row">
+                  <td className="table-column table-cell">
+                    <p className="code">onBack</p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p><b>Function</b></p>
+                  </td>
+                  <td className="table-column table-cell">
+                    <p>Click event handler for the back button</p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>

--- a/client/components/ui-design-system/components/view-modal/react-view-modal.jsx
+++ b/client/components/ui-design-system/components/view-modal/react-view-modal.jsx
@@ -160,7 +160,7 @@ class UIViewModalReact extends React.Component {
                     <p><b>String</b></p>
                   </td>
                   <td className="table-column table-cell">
-                    <p>The header text of the modal</p>
+                    <p>Header text of the modal</p>
                   </td>
                 </tr>
                 <tr className="table-row">
@@ -171,7 +171,7 @@ class UIViewModalReact extends React.Component {
                     <p><b>Node</b></p>
                   </td>
                   <td className="table-column table-cell">
-                    <p>A collection of child elements of the modal body.</p>
+                    <p>A collection of child elements of the modal body</p>
                   </td>
                 </tr>
                 <tr className="table-row">


### PR DESCRIPTION
This PR adds a basic table, which lists a description of each available prop on each React component. 

![screen shot 2017-11-01 at 12 09 40 pm](https://user-images.githubusercontent.com/1957226/32284474-b8674752-befd-11e7-953d-309037ea3b4f.png)
