### PR TITLE
[LG-4631] fix 500 page crash when required prop is deselected

### DIFF
--- a/src/components/live-example/Knob/Knob.tsx
+++ b/src/components/live-example/Knob/Knob.tsx
@@ -69,7 +69,29 @@ export const Knob = ({
 
     case "array":
     case "enum":
-    case "select":
+    case "select": {
+      if (knobOptions && knobOptions.length) {
+        return (
+          (<Select
+            value={value}
+            onChange={onChange}
+            className={cx(inputStyle)}
+            aria-label={propName}
+            renderMode="portal"
+            allowDeselect={true}
+          >
+            {knobOptions.map((opt: KnobOptionType) => (
+              <Option key={opt} value={opt}>
+                {opt}
+              </Option>
+            ))}
+          </Select>)
+        );
+      }
+
+      return <>{`${value}`}</>;
+    }
+
     case "radio": {
       if (knobOptions && knobOptions.length) {
         return (
@@ -78,7 +100,9 @@ export const Knob = ({
             onChange={onChange}
             className={cx(inputStyle)}
             aria-label={propName}
-            renderMode="portal">
+            renderMode="portal"
+            allowDeselect={false}
+          >
             {knobOptions.map((opt: KnobOptionType) => (
               <Option key={opt} value={opt}>
                 {opt}


### PR DESCRIPTION
[LG-4631](https://jira.mongodb.org/browse/LG-4631)

In the live example pages, when a knob uses a `Select` to set the prop value, `allowDeselect={true}` by default. However, the prop value of a deselected option is `""` which in some cases will throw an error and crash the page. Specifically for the `Code` component, deselecting the `language` prop would set `language=""` which is an invalid prop.

This change will set `allowDeselect={false}` for all knobs with control type of `'radio'`. For props like `language` that cannot be deselected, the appropriate storybook control in the storybook file must be set to `type: 'radio'`.

in `*.stories.tsx`
```
propName: {
  options: Object.values(OptionNames),
  control: { type: 'radio' },
}
```